### PR TITLE
Improves conditionals by refactoring it into smaller, more readable methods

### DIFF
--- a/lib/matching_exceptions.rb
+++ b/lib/matching_exceptions.rb
@@ -3,12 +3,20 @@ require "matching_exceptions/version"
 module MatchingExceptions
 
   def self.extended(base)
-    define_method :=== do |other|
-      return false unless other.respond_to?(@method)
-      return other.send(@method).include?(@matching) if @matching.is_a?(String)
-      return other.send(@method) =~ @matching if @matching.is_a?(Regexp)
-      false
+    define_method :=== do |error_message|
+      error_message.respond_to?(@method) && 
+        (matches_string(error_message) || matches_regex(error_message))
     end
+
+    define_method :matches_string do |error_message|
+      @matching.is_a?(String) && error_message.send(@method).include?(@matching)
+    end
+
+    define_method :matches_regex do |error_message|
+      @matching.is_a?(Regexp) && error_message.send(@method) =~ @matching
+    end
+
+    private :===, :matches_string, :matches_regex
   end
 
   extend self

--- a/lib/matching_exceptions.rb
+++ b/lib/matching_exceptions.rb
@@ -22,7 +22,7 @@ module MatchingExceptions
   extend self
 
   def matches(matching, on: 'message')
-    self.tap do
+    tap do
       instance_variable_set(:@matching, matching)
       instance_variable_set(:@method, on)
     end

--- a/lib/matching_exceptions.rb
+++ b/lib/matching_exceptions.rb
@@ -5,18 +5,18 @@ module MatchingExceptions
   def self.extended(base)
     define_method :=== do |error_message|
       error_message.respond_to?(@method) && 
-        (matches_string(error_message) || matches_regex(error_message))
+        (matches_string?(error_message) || matches_regex?(error_message))
     end
 
-    define_method :matches_string do |error_message|
+    define_method :matches_string? do |error_message|
       @matching.is_a?(String) && error_message.send(@method).include?(@matching)
     end
 
-    define_method :matches_regex do |error_message|
+    define_method :matches_regex? do |error_message|
       @matching.is_a?(Regexp) && error_message.send(@method) =~ @matching
     end
 
-    private :===, :matches_string, :matches_regex
+    private :===, :matches_string?, :matches_regex?
   end
 
   extend self

--- a/spec/matching_exceptions_spec.rb
+++ b/spec/matching_exceptions_spec.rb
@@ -76,6 +76,21 @@ RSpec.describe MatchingExceptions do
     expect(rescued).to be_falsy
   end
 
+  context 'when error is raised' do
+    it 'result is always the error caught' do
+      error = nil
+      std_error = StandardError.new("rescue me!")
+
+      begin
+        raise std_error
+      rescue ME.matches(/me!/) => e
+        error = e
+      end
+
+      expect(error).to eq std_error
+    end
+  end
+
   context 'when there are multiple rescues' do
     it 'rescues the correct error' do
       rescued = false

--- a/spec/matching_exceptions_spec.rb
+++ b/spec/matching_exceptions_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe MatchingExceptions do
     expect(rescued).to be_falsy
   end
 
+  it "passing nil returns false" do
+    rescued = false
+
+    begin
+      raise CustomError.new("custom message")
+    rescue ME.matches(nil)
+      rescued = true
+    rescue
+    end
+
+    expect(rescued).to be_falsy
+  end
+
   context 'when there are multiple rescues' do
     it 'rescues the correct error' do
       rescued = false


### PR DESCRIPTION
Maybe it's clearer and more elegant in general to use short-circuit instead of guard clauses mixed with a returning false statement. The resulting methods created were named in order to be explicit about its intentions, namely #matches_string? and #matches_regex?. I wonder if #matches shouldn't have a '?' as well...
Also created a test case for when matches receives nil.